### PR TITLE
SKLL64 でエコーバックを無視

### DIFF
--- a/device.go
+++ b/device.go
@@ -176,6 +176,10 @@ func (d *Device) GetNeibourIP(opts ...Option) (ipAddr string, err error) {
 func (d *Device) getIPAddrFromMacAddr(opts ...Option) (ipAddr string, err error) {
 	callback := func(line string) (bool, error) {
 		// SKLL64コマンドだけはOKを返さず、直後の1行がレスポンス
+		if strings.HasPrefix(line, "SKLL64") {
+			// エコーバックは無視
+			return false, nil
+		}
 		return true, nil
 	}
 	skll64Opts := append([]Option{Reader(callback)}, opts...)


### PR DESCRIPTION
デバイスの設定によっては入力のエコーバックがあります。
ここでほかのコマンドでは `OK` が返ってくるまで待つためエコーバックが問題になることはありませんが、 `SKLL64` では `OK` を待たずに1行目だけを読み込むため、エコーバックが有効な場合には結果ではなくエコーバックを入力行として処理していしまいます。
そのためエコーバックを無視するようにしました。